### PR TITLE
予定タイプが並び順通りに表示されない件を修正。

### DIFF
--- a/app/Http/Controllers/EventTypeController.php
+++ b/app/Http/Controllers/EventTypeController.php
@@ -20,6 +20,13 @@ class EventTypeController extends Controller
         $sortBy = $request->get("sortBy");
         $sortDesc = $request->get("sortDesc");
         $sortStr = "";
+
+        if(!$sortBy){
+            // 並び順が指定されていない場合、デフォルトは「並び順」項目の昇順で表示する。
+            $sortBy = "rank";
+            $sortDesc = "false";
+        }
+
         if($sortDesc == "true") {
             $sortStr = "desc";
         }

--- a/resources/nuxt/pages/event_type/admin/index.vue
+++ b/resources/nuxt/pages/event_type/admin/index.vue
@@ -13,6 +13,8 @@
         class="elevation-1"
         :loading="tableLoading"
         :server-items-length="totalCount"
+        :sort-by.sync="sortBy"
+        :sort-desc.sync="sortDesc"
       >
         <template v-slot:top>
           <v-toolbar flat color="white">
@@ -175,7 +177,9 @@ export default {
 
       // 選択中のオブジェクト
       selectedObj: {},
-      search: '' // フィルタリング検索キーワード
+      search: '', // フィルタリング検索キーワード
+      sortBy: 'rank',
+      sortDesc: false,
     }
   },
   watch: {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #28
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
表示順を何も選択していなかったとき、表示順ではなく作成された時期が早い順で表示される。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
 表示順が選択されなかったときは、表示順の昇順で表示するように変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://user-images.githubusercontent.com/95267222/185545747-26f568a1-1720-4fe3-816e-9ec554ab343e.png)

修正後
![image](https://user-images.githubusercontent.com/95267222/185545470-30e65d9e-3d88-4702-93a1-8060f40fa03c.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
予定タイプ管理の表示の範囲。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
修正としては #32 と同じような内容。