### PR TITLE
#54 Keyupイベントで時刻情報をStateに保存するように修正

### DIFF
--- a/resources/nuxt/components/dialogs/Schedule.vue
+++ b/resources/nuxt/components/dialogs/Schedule.vue
@@ -85,6 +85,7 @@
                     prepend-icon="access_time"
                     label="開始時刻"
                     type="tel"
+                    @keyup="updateStartTime"
                   ></v-combobox>
                 </v-flex>
                 <v-flex sm3 xs6>
@@ -133,6 +134,7 @@
                     prepend-icon="access_time"
                     label="終了時刻"
                     type="tel"
+                    @keyup="updateEndTime"
                   ></v-combobox>
                 </v-flex>
                 <v-flex sm2 xs4>
@@ -736,6 +738,12 @@ export default {
         }
       }
       return times
+    },
+    updateStartTime(e) {
+      this.selected.start_date_time = e.target.value
+    },
+    updateEndTime(e) {
+      this.selected.end_date_time = e.target.value
     },
     async setTypes() {
       var types = []


### PR DESCRIPTION
fix #54 対応
Tabなどでフィールドの移動を行えば変更が反映されるが、Keyupイベント等ではStateの値が更新されないため、明示的にKeyupイベントで変更するように修正